### PR TITLE
Quote framework search paths

### DIFF
--- a/OpenCV.podspec
+++ b/OpenCV.podspec
@@ -77,5 +77,5 @@ Pod::Spec.new do |s|
   
   s.libraries    = 'c++', 'stdc++'  
   s.frameworks = 'opencv2', 'Accelerate', 'AssetsLibrary', 'AVFoundation', 'CoreGraphics', 'CoreImage', 'CoreMedia', 'CoreVideo', 'Foundation', 'QuartzCore', 'UIKit'
-  s.xcconfig = {'FRAMEWORK_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/OpenCV', 'OTHER_LDFLAGS' => '-all_load'}
+  s.xcconfig = {'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(PODS_ROOT)/OpenCV"', 'OTHER_LDFLAGS' => '-all_load'}
 end


### PR DESCRIPTION
POD_ROOTS could be expanded to a path with spaces which would break the path. Quoting the path avoids that.
